### PR TITLE
Remove possible warning for fixed sized oneof cases

### DIFF
--- a/FSharp.GrpcCodeGenerator/FieldConverter.fs
+++ b/FSharp.GrpcCodeGenerator/FieldConverter.fs
@@ -907,10 +907,10 @@ module OneOfFieldConverter =
         ]
 
         for f in fields do
-            ctx.Writer.Write $"| ValueSome ({oneOfCaseName (oneOf, f, containingType, containerMessages, ctx.File)} x) -> size <- size + "
+            ctx.Writer.Write $"| ValueSome ({oneOfCaseName (oneOf, f, containingType, containerMessages, ctx.File)} _x) -> size <- size + "
 
             let conv = SingleFieldConverterFactory.createWriter (f, ctx, Some containingType, containerMessages)
-            conv.WriteSerializedSizeCodeWithoutCheck ctx "x"
+            conv.WriteSerializedSizeCodeWithoutCheck ctx "_x"
             ctx.Writer.WriteLine ""
 
     let writeCloningCode (oneOf: OneOf, containingType: Message) (ctx: FileContext) =


### PR DESCRIPTION
I have a project that treats warning as errors. This should suppress the warning when there is oneof case with only a fixed size property inside of it.